### PR TITLE
[상혁] 4장: API (Github Avatar) 섹션 구현 완료

### DIFF
--- a/04-Web-Component/00-Github-Avatar/README.md
+++ b/04-Web-Component/00-Github-Avatar/README.md
@@ -14,34 +14,34 @@ graph TD;
 
 ## 구현 가이드
 
-- [ ] `components/GitHubAvatar.js` 파일의 `GitHubAvatar` Custom Element Class를 완성해주세요.
+- [x] `components/GitHubAvatar.js` 파일의 `GitHubAvatar` Custom Element Class를 완성해주세요.
 
-  - [ ] `user` 속성이 마크업과 동기화 될 수 있도록 getter/setter를 이용해 관리해야합니다.
-  - [ ] `connectedCallback()` 라이프 사이클 메서드에서는 `img` 요소를 렌더링하고 GitHub API에 요청을 보내야 합니다.
+  - [x] `user` 속성이 마크업과 동기화 될 수 있도록 getter/setter를 이용해 관리해야합니다.
+  - [x] `connectedCallback()` 라이프 사이클 메서드에서는 `img` 요소를 렌더링하고 GitHub API에 요청을 보내야 합니다.
 
-- [ ] GitHub API 요청 결과에 따라 `GitHubAvatar` 구성 요소의 컨텐츠가 달라져야 합니다.
+- [x] GitHub API 요청 결과에 따라 `GitHubAvatar` 구성 요소의 컨텐츠가 달라져야 합니다.
 
   - API 요청 전
 
-    - [ ] 미리 주어진 `LOADING_IMAGE` 아이콘을 표시합니다.
+    - [x] 미리 주어진 `LOADING_IMAGE` 아이콘을 표시합니다.
 
   - API 요청 성공 시
 
-    - [ ] GitHub API 응답 결과인 `avatar_url`을 이용하여 사용자 아바타를 표시합니다.
+    - [x] GitHub API 응답 결과인 `avatar_url`을 이용하여 사용자 아바타를 표시합니다.
 
   - API 요청 실패 시
-    - [ ] 미리 주어진 `ERROR_IMAGE` 아이콘을 표시합니다.
+    - [x] 미리 주어진 `ERROR_IMAGE` 아이콘을 표시합니다.
 
-- [ ] GitHub API 요청 결과에 따라 커스텀 이벤트가 발생해야 합니다.
+- [x] GitHub API 요청 결과에 따라 커스텀 이벤트가 발생해야 합니다.
 
   - API 요청 성공 시
 
-    - [ ] `AVATAR_LOAD_COMPLETE` 커스텀 이벤트를 발생시킵니다.
-    - [ ] 커스텀 이벤트 생성 시 `avatar_url`을 추가적인 데이터로 전달합니다.
+    - [x] `AVATAR_LOAD_COMPLETE` 커스텀 이벤트를 발생시킵니다.
+    - [x] 커스텀 이벤트 생성 시 `avatar_url`을 추가적인 데이터로 전달합니다.
 
   - API 요청 실패 시
-    - [ ] `AVATAR_LOAD_ERROR` 커스텀 이벤트를 발생시킵니다.
-    - [ ] 커스텀 이벤트 생성 시 에러 객체를 추가적인 데이터로 전달합니다.
+    - [x] `AVATAR_LOAD_ERROR` 커스텀 이벤트를 발생시킵니다.
+    - [x] 커스텀 이벤트 생성 시 에러 객체를 추가적인 데이터로 전달합니다.
 
 ## 예시 코드
 

--- a/04-Web-Component/00-Github-Avatar/fecapark/__tests__/application.test.js
+++ b/04-Web-Component/00-Github-Avatar/fecapark/__tests__/application.test.js
@@ -1,0 +1,93 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { jest } from '@jest/globals';
+import GitHubAvatar, { EVENTS, ERROR_IMAGE } from '../components/GitHubAvatar';
+
+describe('GitHubAvatar', () => {
+  beforeAll(() => {
+    customElements.define('github-avatar', GitHubAvatar);
+  });
+
+  let element;
+
+  beforeEach(() => {
+    // requestAnimationFrame을 모킹
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => cb());
+    // GithubAvatar 사용자 정의 요소 생성
+    element = new GitHubAvatar();
+    // body에 사용자 정의 요소 추가
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    // requestAnimationFrame 모킹 제거
+    window.requestAnimationFrame.mockRestore();
+    // body에서 사용자 정의 요소 제거
+    document.body.removeChild(element);
+  });
+
+  it('`user` 속성이 올바르게 설정되어야 한다', () => {
+    const user = 'octocat';
+    element.user = user;
+    expect(element.getAttribute('user')).toBe(user);
+  });
+
+  it('정상적인 `user` 속성이 설정되면 AVATAR_LOAD_COMPLETE 이벤트를 발생시킨다', async () => {
+    const mockUser = 'mockUser';
+    const mockAvatarUrl = 'https://mock.url/avatar.png';
+
+    // avatar_url을 반환하는 fetch를 모킹
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ avatar_url: mockAvatarUrl }),
+      }),
+    );
+
+    // AVATAR_LOAD_COMPLETE 이벤트 리스너를 등록
+    const loadCompleteHandler = jest.fn();
+    element.addEventListener(EVENTS.AVATAR_LOAD_COMPLETE, loadCompleteHandler);
+
+    // user 속성을 설정
+    element.user = mockUser;
+    element.connectedCallback();
+
+    // 모든 비동기 작업이 완료될 때까지 대기
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    // AVATAR_LOAD_COMPLETE 이벤트가 발생하였는지 확인
+    expect(loadCompleteHandler).toHaveBeenCalled();
+
+    // img 요소의 src 속성이 변경되었는지 확인
+    const img = element.querySelector('img');
+    expect(img.src).toBe(mockAvatarUrl);
+  });
+
+  it('비정상적인 `user` 속성이 설정되면 AVATAR_LOAD_ERROR 이벤트를 발생시킨다', async () => {
+    const mockUser = 'mockUser';
+
+    // 에러를 던지는 fetch를 모킹
+    global.fetch = jest.fn().mockImplementation(() => Promise.reject(new Error('Not Found')));
+
+    // AVATAR_LOAD_ERROR 이벤트 리스너를 등록
+    const loadErrorHandler = jest.fn();
+    element.addEventListener(EVENTS.AVATAR_LOAD_ERROR, loadErrorHandler);
+
+    // user 속성을 설정
+    element.user = mockUser;
+    element.connectedCallback();
+
+    // 모든 비동기 작업이 완료될 때까지 대기
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    // AVATAR_LOAD_ERROR 이벤트가 발생하였는지 확인
+    expect(loadErrorHandler).toHaveBeenCalled();
+
+    // img 요소의 src 속성이 변경되었는지 확인
+    const img = element.querySelector('img');
+    expect(img.src).toBe(ERROR_IMAGE);
+  });
+});

--- a/04-Web-Component/00-Github-Avatar/fecapark/components/GitHubAvatar.js
+++ b/04-Web-Component/00-Github-Avatar/fecapark/components/GitHubAvatar.js
@@ -1,0 +1,89 @@
+/* eslint-disable no-unused-vars */
+export const ERROR_IMAGE = 'https://cdn-icons-png.flaticon.com/512/1304/1304038.png';
+const LOADING_IMAGE = 'https://cdn-icons-png.flaticon.com/512/3305/3305803.png';
+const AVATAR_LOAD_COMPLETE = 'AVATAR_LOAD_COMPLETE';
+const AVATAR_LOAD_ERROR = 'AVATAR_LOAD_ERROR';
+
+export const EVENTS = {
+  AVATAR_LOAD_COMPLETE,
+  AVATAR_LOAD_ERROR,
+};
+
+const getGitHubAvatarUrl = async (user) => {
+  if (!user) return null;
+
+  const url = `https://api.github.com/users/${user}`;
+
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+
+  const data = await response.json();
+  return data.avatar_url;
+};
+
+export default class GitHubAvatar extends HTMLElement {
+  constructor() {
+    super();
+    this.url = LOADING_IMAGE;
+  }
+
+  get user() {
+    return this.getAttribute('user');
+  }
+
+  set user(value) {
+    this.setAttribute('user', value);
+  }
+
+  async loadNewAvatar() {
+    const { user } = this;
+    if (!user) return;
+
+    try {
+      this.url = await getGitHubAvatarUrl(user);
+      this.onLoadAvatarComplete();
+    } catch (error) {
+      this.url = ERROR_IMAGE;
+      this.onLoadAvatarError(error);
+    }
+
+    this.render();
+  }
+
+  render() {
+    requestAnimationFrame(() => {
+      this.innerHTML = '';
+
+      const img = document.createElement('img');
+      img.src = this.url;
+
+      this.appendChild(img);
+    });
+  }
+
+  connectedCallback() {
+    this.render();
+    this.loadNewAvatar();
+  }
+
+  onLoadAvatarComplete() {
+    const event = new CustomEvent(AVATAR_LOAD_COMPLETE, {
+      detail: {
+        avatar: this.url,
+      },
+    });
+    this.dispatchEvent(event);
+  }
+
+  onLoadAvatarError(error) {
+    const event = new CustomEvent(AVATAR_LOAD_ERROR, {
+      detail: {
+        error,
+      },
+    });
+    this.dispatchEvent(event);
+  }
+}

--- a/04-Web-Component/00-Github-Avatar/fecapark/index.html
+++ b/04-Web-Component/00-Github-Avatar/fecapark/index.html
@@ -1,0 +1,32 @@
+<html>
+  <head>
+    <link rel="shortcut icon" href="../favicon.ico" />
+    <title>Frameworkless Frontend Development: Web Components</title>
+    <style>
+      img {
+        width: 50px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <github-avatar user="2wndrhs"></github-avatar>
+    <github-avatar user="SujinKim1127"></github-avatar>
+    <github-avatar user="fecapark"></github-avatar>
+    <github-avatar user="Oilwoo"></github-avatar>
+    <github-avatar user="Hanna922"></github-avatar>
+    <github-avatar user="dummy_user"></github-avatar>
+    <div>
+      Icons made by
+      <a href="https://www.flaticon.com/authors/Freepik" title="Eleonor Wang">Freepik</a>
+      from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a> is licensed by
+      <a
+        href="http://creativecommons.org/licenses/by/3.0/"
+        title="Creative Commons BY 3.0"
+        target="_blank"
+        >CC 3.0 BY</a
+      >
+    </div>
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/04-Web-Component/00-Github-Avatar/fecapark/index.js
+++ b/04-Web-Component/00-Github-Avatar/fecapark/index.js
@@ -1,0 +1,13 @@
+import GitHubAvatar, { EVENTS } from './components/GitHubAvatar.js';
+
+window.customElements.define('github-avatar', GitHubAvatar);
+
+document.querySelectorAll('github-avatar').forEach((avatar) => {
+  avatar.addEventListener(EVENTS.AVATAR_LOAD_COMPLETE, (e) => {
+    console.log('Avatar Loaded', e.detail.avatar);
+  });
+
+  avatar.addEventListener(EVENTS.AVATAR_LOAD_ERROR, (e) => {
+    console.log('Avatar Loading error', e.detail.error);
+  });
+});


### PR DESCRIPTION
## PR 설명

Custom Element 정말 신기하네요...
예전에 코딩애플 유튜브 영상으로 잠깐 본적 있었는데 실제로 써보게 될 줄은 몰랐습니당..
깃허브는 거의 모든 코드가 이 방식으로 구현되어 있다는데 너무 신기하네요 ㄷㄷ

Custom Event 를 제작하는 패턴이 뭔가 재밌다고 느꼈습니다.
원하는 시점과 위치에서 dispatch 해주고, 그냥 그 이벤트를 받아오는 로직만 짜면 되니까요!

만약에 커스텀 이벤트를 만드는 리액트 훅을 만들어서 
특정 jsx element의 `ref` 만 넘겨주는 방식으로 구현한다면 
굳이 prop drilling 이 크게 필요없지 않을까 하는 생각도 드네요.


Fixes #(issue)

## 체크리스트

- [x] 로컬에서 변경 사항을 테스트해 본 결과 예상대로 작동했습니다.
- [x] 필요한 경우 적절한 문서나 설명을 추가했습니다.
- [x] 프로젝트의 코딩 스타일과 규칙을 따랐습니다.
- [x] 리뷰어를 올바르게 지정했습니다.
